### PR TITLE
Reconfigure search

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testPathIgnorePatterns: [
+    'node_modules',
+  ],
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.json',
+    },
+  },
+  moduleDirectories: [
+    'node_modules',
+  ],
+  testEnvironment: 'node',
+  testRegex: 'test.ts$',
+  transform: {
+    '^.+\\.test.(ts|tsx)$': 'ts-jest',
+  },
+  preset: 'ts-jest',
+  testMatch: null
+}

--- a/package.json
+++ b/package.json
@@ -12,23 +12,6 @@
     "jest": "^23.6.0",
     "ts-jest": "^23.10.5"
   },
-  "jest": {
-    "transform": {
-      "^.+\\.(ts|d\\.ts)?$": "ts-jest"
-    },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.ts?$",
-    "moduleFileExtensions": [
-      "js",
-      "ts"
-    ],
-    "moduleDirectories": [
-      "node_modules"
-    ],
-    "modulePaths": [
-      "<rootDir>/src/",
-      "<rootDir>/node_modules"
-    ]
-  },
   "devDependencies": {
     "@types/jest": "^23.3.10",
     "typescript": "^3.2.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
-  "compilerOptions": {
-    "target": "ES5",
-    "lib": ["esnext", "esnext.asynciterable"],
-    "moduleResolution": "node",
-    "module": "CommonJS",
-//    "baseUrl": ".",
-//    "paths": {
-//      "*": ["node_modules/"]
-//    },
-    "strict": true,
-//    "forceConsistentCasingInFileNames": true,
-//    "noImplicitReturns": true,
-//    //TODO: "noUnusedLocals": true,
-//    "sourceMap": true,
-//    "inlineSources": true,
-//    "typeRoots": ["node_modules/@types", "node_modules/@types/web3/eth"],
-//    "outDir": "dist",
-    "allowSyntheticDefaultImports": true
-  }
+    "compilerOptions": {
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "target": "es6",
+        "noImplicitAny": true,
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "outDir": "dist",
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "node_modules/*",
+                "src/types/*"
+            ]
+        }
+    },
+    "include": [
+        "src/**/*"
+    ]
 }


### PR DESCRIPTION
1. Extract jest section from package.json and save in jest.config.js
2. Use ts-jest config:migrate to update jest.config.js
3. update compilerOptions in tsconfig.json